### PR TITLE
Make CUB compilable without Jitify

### DIFF
--- a/cub/cub/detail/detect_cuda_runtime.cuh
+++ b/cub/cub/detail/detect_cuda_runtime.cuh
@@ -44,7 +44,10 @@
 #  pragma system_header
 #endif // no system header
 
+// CUDA headers might not be present when using NVRTC, see NVIDIA/cccl#2095 for detail
+#ifndef __CUDACC_RTC__
 #include <cuda_runtime_api.h>
+#endif
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS // Only parse this during doxygen passes:
 


### PR DESCRIPTION
xref: https://github.com/cupy/cupy/pull/8412#issuecomment-2256214056

We probably need to create a new branch based on `main`, instead of merging this to `main` directly. ~~However, I do not have access to this repo.~~ **UPDATE**: I created a new branch `fix_cupy_8412` from `main`.